### PR TITLE
Forced build to use gradle version 7.3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Set up Gradle
         uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 7.3.2
 
       - name: Gradle Wrapper
         run: "gradle wrapper"


### PR DESCRIPTION
- Forced ci/cd pipeline to use Gradle 7.3.2 version during build process.